### PR TITLE
fix/get_selection_has_already_been_declared

### DIFF
--- a/copy-text-and-url/getSelection.js
+++ b/copy-text-and-url/getSelection.js
@@ -1,2 +1,4 @@
-const selectedText = window.getSelection().toString();
-chrome.runtime.sendMessage({ action: 'selectedText', data: selectedText });
+(function () {
+  const selectedText = window.getSelection().toString();
+  chrome.runtime.sendMessage({ action: 'selectedText', data: selectedText });
+})();


### PR DESCRIPTION
Resolved an error caused by re-declaring a variable in getSelection.js by wrapping the script in an IIFE to ensure a fresh local scope on each execution.


> The error you're seeing is due to re-declaring the selectedText variable in the getSelection.js script. Every time you inject the script into a tab, the variable declaration will be attempted again, and since scripts injected into a tab share the same context, you'll get this error if the script is injected more than once into the same tab.
> 
> To fix this issue, you can utilize an Immediately Invoked Function Expression (IIFE) to wrap your code in getSelection.js. This way, each time the script is executed, the variables will be in their own local scope and won't conflict with previous invocations:
